### PR TITLE
Remove git rm and file copy steps from build workflow

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -37,8 +37,6 @@ jobs:
           git config user.email "actions@github.com"
 
           git checkout --orphan build
-          git rm -rf .
-          cp -r dist/* ./
 
           git add .
           git commit -m "Build output from ${GITHUB_SHA}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build workflow to simplify the process of preparing the distribution output for deployment. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->